### PR TITLE
Allow the caller to supply their own Writer implementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Cargo.lock
 # Testing
 examples/tester.rs
 output
+*~
+/.gdb_history

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(warnings, missing_docs, clippy::pedantic, clippy::all)]
 #![warn(rust_2018_idioms)]
+#![feature(min_specialization)]
 
 //! Rucline, the Rust CLI Line reader, or simply "recline", is a cross-platform, UTF-8 compatible
 //! line reader that provides hooks for autocompletion and tab suggestion. It supports advanced

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -32,10 +32,11 @@
 
 mod builder;
 mod context;
-mod writer;
+
+pub mod writer;
 
 use context::Context;
-use writer::Writer;
+use writer::{RuclineWriter, Writer};
 
 use crate::actions::{action_for, Action, Direction, Overrider, Range, Scope};
 use crate::completion::{Completer, Suggester};
@@ -145,22 +146,21 @@ impl Outcome {
 /// [`Outcome`]: enum.Outcome.html
 /// [`Prompt`]: struct.Prompt.html
 /// [`buffer`]: ../buffer/struct.Buffer.html
-pub fn read_line<O, C, S>(
-    prompt: Option<&str>,
+pub fn read_line<O, C, S, W>(
     buffer: Option<Buffer>,
-    erase_after_read: bool,
     overrider: Option<&O>,
     completer: Option<&C>,
     suggester: Option<&S>,
+    writer: &mut W,
 ) -> Result<Outcome, crate::Error>
 where
     O: Overrider + ?Sized,
     C: Completer + ?Sized,
     S: Suggester + ?Sized,
+    W: Writer + ?Sized,
 {
     let mut context = Context::new(
-        erase_after_read,
-        prompt.as_deref(),
+        writer,
         buffer,
         completer,
         suggester,


### PR DESCRIPTION
This lets the caller print the REPL in any style they want.