### PR TITLE
Allow hiding suggestion options with a flag

### DIFF
--- a/src/prompt/builder.rs
+++ b/src/prompt/builder.rs
@@ -16,6 +16,11 @@ macro_rules! impl_builder {
             self.base = self.base.erase_after_read(erase_after_read);
             self
         }
+
+        fn display_suggestion_options(mut self, display_suggestion_options: bool) -> Self {
+            self.base = self.base.display_suggestion_options(display_suggestion_options);
+            self
+        }
     };
 
     (extensions) => {
@@ -185,6 +190,18 @@ pub trait Builder: ChainedLineReader + Sized {
     #[must_use]
     fn erase_after_read(self, erase_after_read: bool) -> Self;
 
+    /// Controls if a list of options should be displayed when suggesting.
+    ///
+    /// If set to `true` (default), when requiring suggestions, the prompt will be updated and a
+    /// list of possible suggestions will be rendered underneath.
+    ///
+    /// If set to `false`, only the prompt will be updated.
+    ///
+    /// # Arguments
+    /// * `erase_after_read` - Whether a list of options should be displayed when suggesting.
+    #[must_use]
+    fn display_suggestion_options(self, display_suggestion_options: bool) -> Self;
+
     /// Modifies the behavior of the prompt by setting an [`Overrider`].
     ///
     /// The builder will take ownership of [`overrider`]. To pass in a reference, use
@@ -321,6 +338,7 @@ pub struct Prompt {
     prompt: Option<String>,
     buffer: Option<Buffer>,
     erase_after_read: bool,
+    display_suggestion_options: bool,
 }
 
 impl Prompt {
@@ -333,6 +351,7 @@ impl Prompt {
             prompt: None,
             buffer: None,
             erase_after_read: false,
+            display_suggestion_options: true,
         }
     }
 }
@@ -349,6 +368,7 @@ impl<S: ToString> std::convert::From<S> for Prompt {
             prompt: Some(s.to_string()),
             buffer: None,
             erase_after_read: false,
+            display_suggestion_options: true,
         }
     }
 }
@@ -418,6 +438,11 @@ impl Builder for Prompt {
         self
     }
 
+    fn display_suggestion_options(mut self, display_suggestion_options: bool) -> Self {
+        self.display_suggestion_options = display_suggestion_options;
+        self
+    }
+
     impl_builder!(extensions);
 
     fn read_line(self) -> Result<Outcome, Error> {
@@ -425,6 +450,7 @@ impl Builder for Prompt {
             self.prompt.as_deref(),
             self.buffer,
             self.erase_after_read,
+            self.display_suggestion_options,
             None,
             None,
             None,
@@ -532,6 +558,7 @@ impl ChainedLineReader for Prompt {
             self.prompt.as_deref(),
             self.buffer,
             self.erase_after_read,
+            self.display_suggestion_options,
             overrider,
             completer,
             suggester,
@@ -769,6 +796,10 @@ mod test {
             }
 
             fn erase_after_read(self, _: bool) -> Self {
+                unimplemented!()
+            }
+
+            fn display_suggestion_options(self, _: bool) -> Self {
                 unimplemented!()
             }
 

--- a/src/prompt/mod.rs
+++ b/src/prompt/mod.rs
@@ -151,6 +151,7 @@ pub fn read_line<O, C, S>(
     prompt: Option<&str>,
     buffer: Option<Buffer>,
     erase_after_read: bool,
+    display_suggestion_options: bool,
     overrider: Option<&O>,
     completer: Option<&C>,
     suggester: Option<&S>,
@@ -160,7 +161,14 @@ where
     C: Completer + ?Sized,
     S: Suggester + ?Sized,
 {
-    let mut context = Context::new(erase_after_read, prompt, buffer, completer, suggester)?;
+    let mut context = Context::new(
+        erase_after_read,
+        display_suggestion_options,
+        prompt,
+        buffer,
+        completer,
+        suggester,
+    )?;
 
     context.print()?;
     loop {


### PR DESCRIPTION
Hey @m-lima, really cool project!

I've added a flag that allows hiding the suggestion options list when cycling through options. 

The motivation is that I would like to use the suggestion to display a command history (similar to, for ex, to bash) and the suggestion option list was taking too much space for my taste. I've therefore split the display of the selected option from the display of the option list into two distinct functions and gated the latter behind a `display_suggestion_options` flag. The default behavior should be unchanged.  Hope the way I've done it is fine, don't hesitate to tell me otherwise and I'll try to adapt the PR.